### PR TITLE
Use atoum tools to write better tests

### DIFF
--- a/.atoum.php
+++ b/.atoum.php
@@ -1,0 +1,3 @@
+<?php
+
+$runner->addTestsFromDirectory(__DIR__ . '/tests/units');

--- a/.bootstrap.atoum.php
+++ b/.bootstrap.atoum.php
@@ -1,0 +1,3 @@
+<?php
+
+$runner->addTestsFromDirectory(__DIR__ . '/tests/units');

--- a/.bootstrap.atoum.php
+++ b/.bootstrap.atoum.php
@@ -1,3 +1,3 @@
 <?php
 
-$runner->addTestsFromDirectory(__DIR__ . '/tests/units');
+require_once __DIR__ . '/vendor/autoload.php';

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ php:
 script: 
  - composer install
  - mkdir -p build/logs
- - php vendor/atoum/atoum/bin/atoum -c travis-coverage.php -d tests/units/
+ - php vendor/atoum/atoum/bin/atoum -c travis-coverage.php
 
 after_script:
  - php vendor/bin/coveralls -v

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "aws/aws-sdk-php": ">=2.7"
   },
   "require-dev": {
-    "atoum/atoum": "dev-master",
+    "atoum/atoum": "~2",
     "satooshi/php-coveralls": "dev-master"
   },
   "autoload": {

--- a/tests/units/Adapter/FileAdapter.php
+++ b/tests/units/Adapter/FileAdapter.php
@@ -34,10 +34,9 @@ class FileAdapter extends atoum\test
             });
     }
 
-    public function testFileAdapter__construct()
+    public function testFileAdapterClass()
     {
-        $this->given()
-            ->class(new \ReputationVIP\QueueClient\Adapter\FileAdapter('/tmp/test/'))->hasInterface('\ReputationVIP\QueueClient\Adapter\AdapterInterface');
+        $this->testedClass->implements('\ReputationVIP\QueueClient\Adapter\AdapterInterface');
     }
 
     public function testFileAdapterDeleteQueue()

--- a/tests/units/Adapter/FileAdapter.php
+++ b/tests/units/Adapter/FileAdapter.php
@@ -2,8 +2,6 @@
 
 namespace ReputationVIP\QueueClient\tests\units\Adapter;
 
-require_once __DIR__ . '/../../../vendor/autoload.php';
-
 use ArrayIterator;
 use mageekguy\atoum;
 use ReputationVIP\QueueClient\PriorityHandler\ThreeLevelPriorityHandler;

--- a/tests/units/Adapter/FileAdapter.php
+++ b/tests/units/Adapter/FileAdapter.php
@@ -20,6 +20,16 @@ class MockIOExceptionInterface extends \Exception implements IOExceptionInterfac
 
 class FileAdapter extends atoum\test
 {
+    public function testFileAdapterClass()
+    {
+        $this->testedClass->implements('\ReputationVIP\QueueClient\Adapter\AdapterInterface');
+    }
+
+    public function testFileAdapter__construct()
+    {
+        $this->object($this->newTestedInstance('/tmp/test/'));
+    }
+
     public function testFileAdapter__constructWithFilesystemError(Filesystem $fs, Finder $finder, LockHandlerFactory $lockHandlerFactory)
     {
         $this->exception(function () use($fs, $finder, $lockHandlerFactory) {
@@ -32,11 +42,6 @@ class FileAdapter extends atoum\test
         $this->exception(function () use($fs, $finder, $lockHandlerFactory) {
                 $this->newTestedInstance('/tmp/test/', null, $fs, $finder, $lockHandlerFactory);
             });
-    }
-
-    public function testFileAdapterClass()
-    {
-        $this->testedClass->implements('\ReputationVIP\QueueClient\Adapter\AdapterInterface');
     }
 
     public function testFileAdapterDeleteQueue()

--- a/tests/units/Adapter/MemoryAdapter.php
+++ b/tests/units/Adapter/MemoryAdapter.php
@@ -2,8 +2,6 @@
 
 namespace ReputationVIP\QueueClient\tests\units\Adapter;
 
-require_once __DIR__ . '/../../../vendor/autoload.php';
-
 use mageekguy\atoum;
 use ReputationVIP\QueueClient\PriorityHandler\ThreeLevelPriorityHandler;
 

--- a/tests/units/Adapter/MemoryAdapter.php
+++ b/tests/units/Adapter/MemoryAdapter.php
@@ -9,10 +9,9 @@ class MemoryAdapter extends atoum\test
 {
     public function testMemoryAdapterCreateQueue()
     {
-        $MemoryAdapter = new \ReputationVIP\QueueClient\Adapter\MemoryAdapter();
-
-        $this->given($MemoryAdapter)
-            ->class($MemoryAdapter->createQueue('testQueue'))->hasInterface('\ReputationVIP\QueueClient\Adapter\AdapterInterface');
+        $this->given($this->newTestedInstance)
+            ->object($this->testedInstance->createQueue('testQueue'))->isTestedInstance()
+        ;
     }
 
     public function testMemoryAdapterCreateQueueWithEmptyQueueName()
@@ -35,39 +34,46 @@ class MemoryAdapter extends atoum\test
 
     public function testMemoryAdapterCreateQueueWithQueueExists()
     {
-        $MemoryAdapter = new \ReputationVIP\QueueClient\Adapter\MemoryAdapter();
-
-        $MemoryAdapter->createQueue('testQueue');
-        $this->exception(function() use($MemoryAdapter) {
-            $MemoryAdapter->createQueue('testQueue');
-        });
+        $this
+            ->given($this->newTestedInstance)
+            ->when($this->testedInstance->createQueue('testQueue'))
+            ->then
+                ->exception(function() {
+                    $this->testedInstance->createQueue('testQueue');
+                })
+        ;
     }
 
     public function testMemoryAdapterDeleteQueue()
     {
-        $MemoryAdapter = new \ReputationVIP\QueueClient\Adapter\MemoryAdapter();
-
-        $MemoryAdapter->createQueue('testQueue');
-        $this->given($MemoryAdapter)
-            ->class($MemoryAdapter->deleteQueue('testQueue'))->hasInterface('\ReputationVIP\QueueClient\Adapter\AdapterInterface');
+        $this
+            ->given($this->newTestedInstance)
+            ->when($this->testedInstance->createQueue('testQueue'))
+            ->then
+                ->object($this->testedInstance->deleteQueue('testQueue'))->isTestedInstance()
+        ;
     }
 
     public function testMemoryAdapterDeleteQueueWithEmptyQueueName()
     {
-        $MemoryAdapter = new \ReputationVIP\QueueClient\Adapter\MemoryAdapter();
-
-        $this->exception(function() use($MemoryAdapter) {
-            $MemoryAdapter->deleteQueue('');
-        });
+        $this
+            ->given($this->newTestedInstance)
+            ->then
+                ->exception(function() {
+                    $this->testedInstance->deleteQueue('');
+                })
+        ;
     }
 
     public function testMemoryAdapterDeleteQueueWithQueueDoesNotExists()
     {
-        $MemoryAdapter = new \ReputationVIP\QueueClient\Adapter\MemoryAdapter();
-
-        $this->exception(function() use($MemoryAdapter) {
-            $MemoryAdapter->deleteQueue('testQueue');
-        });
+        $this
+            ->given($this->newTestedInstance)
+            ->then
+                ->exception(function() {
+                    $this->testedInstance->deleteQueue('testQueue');
+                })
+        ;
     }
 
     public function testMemoryAdapterRenameQueue()

--- a/tests/units/Adapter/NullAdapter.php
+++ b/tests/units/Adapter/NullAdapter.php
@@ -2,8 +2,6 @@
 
 namespace ReputationVIP\QueueClient\tests\units\Adapter;
 
-require_once __DIR__ . '/../../../vendor/autoload.php';
-
 use mageekguy\atoum;
 
 class NullAdapter extends atoum\test

--- a/tests/units/Adapter/SQSAdapter.php
+++ b/tests/units/Adapter/SQSAdapter.php
@@ -2,8 +2,6 @@
 
 namespace ReputationVIP\QueueClient\tests\units\Adapter;
 
-require_once __DIR__ . '/../../../vendor/autoload.php';
-
 use mageekguy\atoum;
 use ReputationVIP\QueueClient\PriorityHandler\ThreeLevelPriorityHandler;
 

--- a/tests/units/PriorityHandler/StandardPriorityHandler.php
+++ b/tests/units/PriorityHandler/StandardPriorityHandler.php
@@ -2,8 +2,6 @@
 
 namespace ReputationVIP\QueueClient\tests\units\PriorityHandler;
 
-require_once __DIR__ . '/../../../vendor/autoload.php';
-
 use mageekguy\atoum;
 
 class StandardPriorityHandler extends atoum\test

--- a/tests/units/QueueClient.php
+++ b/tests/units/QueueClient.php
@@ -9,38 +9,43 @@ class QueueClient extends atoum\test
 {
     public function testQueueClient__construct()
     {
-        $this->class(new \ReputationVIP\QueueClient\QueueClient())->hasInterface('ReputationVIP\QueueClient\QueueClientInterface');
+        $this->testedClass->implements('ReputationVIP\QueueClient\QueueClientInterface');
     }
 
     public function testQueueClientAddMessageWithAlias()
     {
-        $queueClient = new \ReputationVIP\QueueClient\QueueClient(new MemoryAdapter());
-
-        $queueClient->createQueue('testQueueOne');
-        $queueClient->createQueue('testQueueTwo');
-        $queueClient->addAlias('testQueueOne', 'queueAlias');
-        $this->class($queueClient->addMessage('queueAlias', 'testMessage'))->hasInterface('ReputationVIP\QueueClient\QueueClientInterface');
-        $queueClient->addAlias('testQueueTwo', 'queueAlias');
-        $this->class($queueClient->addMessage('queueAlias', 'testMessage'))->hasInterface('ReputationVIP\QueueClient\QueueClientInterface');
+        $this
+            ->given($this->newTestedInstance(new MemoryAdapter()))
+            ->when(
+                $this->testedInstance->createQueue('testQueueOne'),
+                $this->testedInstance->createQueue('testQueueTwo'),
+                $this->testedInstance->addAlias('testQueueOne', 'queueAlias')
+            )
+            ->then
+                ->object($this->testedInstance->addMessage('queueAlias', 'testMessage'))->isTestedInstance()
+            ->when($this->testedInstance->addAlias('testQueueTwo', 'queueAlias'))
+            ->then
+                ->object($this->testedInstance->addMessage('queueAlias', 'testMessage'))->isTestedInstance()
+        ;
     }
 
     public function testQueueClientAddMessage()
     {
-        $queueClient = new \ReputationVIP\QueueClient\QueueClient();
+        $queueClient = $this->newTestedInstance();
 
-        $this->class($queueClient->addMessage('testQueue', 'testMessage'))->hasInterface('ReputationVIP\QueueClient\QueueClientInterface');
+        $this->object($queueClient->addMessage('testQueue', 'testMessage'))->isTestedInstance();
     }
 
     public function testQueueClientAddMessages()
     {
-        $queueClient = new \ReputationVIP\QueueClient\QueueClient();
+        $queueClient = $this->newTestedInstance();
 
-        $this->class($queueClient->addMessages('testQueue', ['testMessageOne', 'testMessageTwo', 'testMessageThree']))->hasInterface('ReputationVIP\QueueClient\QueueClientInterface');
+        $this->object($queueClient->addMessages('testQueue', ['testMessageOne', 'testMessageTwo', 'testMessageThree']))->isTestedInstance();
     }
 
     public function testQueueClientGetMessagesWithAlias()
     {
-        $queueClient = new \ReputationVIP\QueueClient\QueueClient(new MemoryAdapter());
+        $queueClient = $this->newTestedInstance(new MemoryAdapter());
 
         $queueClient->createQueue('testQueueOne');
         $queueClient->createQueue('testQueueTwo');
@@ -53,7 +58,7 @@ class QueueClient extends atoum\test
 
     public function testQueueClientGetMessages()
     {
-        $queueClient = new \ReputationVIP\QueueClient\QueueClient(new MemoryAdapter());
+        $queueClient = $this->newTestedInstance(new MemoryAdapter());
 
         $queueClient->createQueue('testQueue');
         $this->given($queueClient)
@@ -62,7 +67,7 @@ class QueueClient extends atoum\test
 
     public function testQueueClientDeleteMessageWithAlias()
     {
-        $queueClient = new \ReputationVIP\QueueClient\QueueClient(new MemoryAdapter());
+        $queueClient = $this->newTestedInstance(new MemoryAdapter());
 
         $queueClient->createQueue('testQueueOne');
         $queueClient->createQueue('testQueueTwo');
@@ -75,22 +80,22 @@ class QueueClient extends atoum\test
 
     public function testQueueClientDeleteMessage()
     {
-        $queueClient = new \ReputationVIP\QueueClient\QueueClient();
+        $queueClient = $this->newTestedInstance();
 
         $queueClient->createQueue('testQueue');
-        $this->class($queueClient->deleteMessage('testQueue', 'testMessage'))->hasInterface('ReputationVIP\QueueClient\QueueClientInterface');
+        $this->object($queueClient->deleteMessage('testQueue', 'testMessage'))->isTestedInstance();
     }
 
     public function testQueueClientDeleteMessages()
     {
-        $queueClient = new \ReputationVIP\QueueClient\QueueClient();
+        $queueClient = $this->newTestedInstance();
 
-        $this->class($queueClient->deleteMessages('testQueue', ['testMessageOne', 'testMessageTwo', 'testMessageThree']))->hasInterface('ReputationVIP\QueueClient\QueueClientInterface');
+        $this->object($queueClient->deleteMessages('testQueue', ['testMessageOne', 'testMessageTwo', 'testMessageThree']))->isTestedInstance();
     }
 
     public function testQueueClientIsEmptyWithAlias()
     {
-        $queueClient = new \ReputationVIP\QueueClient\QueueClient(new MemoryAdapter());
+        $queueClient = $this->newTestedInstance(new MemoryAdapter());
 
         $queueClient->createQueue('testQueueOne');
         $queueClient->createQueue('testQueueTwo');
@@ -103,16 +108,15 @@ class QueueClient extends atoum\test
 
     public function testQueueClientIsEmpty()
     {
-        $queueClient = new \ReputationVIP\QueueClient\QueueClient();
+        $queueClient = $this->newTestedInstance();
 
-        $queueClient->createQueue('testQueue');
-        $this->given($queueClient)
+        $this->given($queueClient->createQueue('testQueue'))
             ->boolean($queueClient->isEmpty('testQueue'));
     }
 
     public function testQueueClientGetNumberMessageWithAlias()
     {
-        $queueClient = new \ReputationVIP\QueueClient\QueueClient(new MemoryAdapter());
+        $queueClient = $this->newTestedInstance(new MemoryAdapter());
 
         $queueClient->createQueue('testQueueOne');
         $queueClient->createQueue('testQueueTwo');
@@ -125,61 +129,60 @@ class QueueClient extends atoum\test
 
     public function testQueueClientNumberMessage()
     {
-        $queueClient = new \ReputationVIP\QueueClient\QueueClient();
+        $queueClient = $this->newTestedInstance();
 
-        $queueClient->createQueue('testQueue');
-        $this->given($queueClient)
-            ->integer($queueClient->getNumberMessages('testQueue'));
+        $this->given($queueClient->createQueue('testQueue'))
+            ->integer($queueClient->getNumberMessages('testQueue'))->isZero();
     }
 
     public function testQueueClientDeleteQueueWithAlias()
     {
-        $queueClient = new \ReputationVIP\QueueClient\QueueClient(new MemoryAdapter());
+        $queueClient = $this->newTestedInstance(new MemoryAdapter());
 
         $queueClient->createQueue('testQueue');
         $queueClient->addAlias('testQueue', 'queueAliasOne');
         $queueClient->addAlias('testQueue', 'queueAliasTwo');
-        $this->class($queueClient->deleteQueue('testQueue'))->hasInterface('ReputationVIP\QueueClient\QueueClientInterface');
+        $this->object($queueClient->deleteQueue('testQueue'))->isTestedInstance();
         $this->given($queueClient)
             ->array($queueClient->getAliases())->isEmpty();
     }
 
     public function testQueueClientDeleteQueue()
     {
-        $queueClient = new \ReputationVIP\QueueClient\QueueClient();
+        $queueClient = $this->newTestedInstance();
 
-        $this->class($queueClient->deleteQueue('testQueue'))->hasInterface('ReputationVIP\QueueClient\QueueClientInterface');
+        $this->object($queueClient->deleteQueue('testQueue'))->isTestedInstance();
     }
 
     public function testQueueClientCreateQueue()
     {
-        $queueClient = new \ReputationVIP\QueueClient\QueueClient();
+        $queueClient = $this->newTestedInstance();
 
-        $this->class($queueClient->createQueue('testQueue'))->hasInterface('ReputationVIP\QueueClient\QueueClientInterface');
+        $this->object($queueClient->createQueue('testQueue'))->isTestedInstance();
     }
 
     public function testQueueClientRenameQueueWithAlias()
     {
-        $queueClient = new \ReputationVIP\QueueClient\QueueClient(new MemoryAdapter());
+        $queueClient = $this->newTestedInstance(new MemoryAdapter());
 
         $queueClient->createQueue('testQueue');
         $queueClient->addAlias('testQueue', 'queueAliasOne');
         $queueClient->addAlias('testQueue', 'queueAliasTwo');
-        $this->class($queueClient->renameQueue('testQueue', 'testRenameQueue'))->hasInterface('ReputationVIP\QueueClient\QueueClientInterface');
+        $this->object($queueClient->renameQueue('testQueue', 'testRenameQueue'))->isTestedInstance();
         $this->given($queueClient)
             ->array($queueClient->getAliases())->isIdenticalTo(['queueAliasOne' => ['testRenameQueue'], 'queueAliasTwo' => ['testRenameQueue']]);
     }
 
     public function testQueueClientRenameQueue()
     {
-        $queueClient = new \ReputationVIP\QueueClient\QueueClient();
+        $queueClient = $this->newTestedInstance();
 
-        $this->class($queueClient->renameQueue('testQueue', 'testRenameQueue'))->hasInterface('ReputationVIP\QueueClient\QueueClientInterface');
+        $this->object($queueClient->renameQueue('testQueue', 'testRenameQueue'))->isTestedInstance();
     }
 
     public function testQueueClientPurgeQueueWithAlias()
     {
-        $queueClient = new \ReputationVIP\QueueClient\QueueClient(new MemoryAdapter());
+        $queueClient = $this->newTestedInstance(new MemoryAdapter());
 
         $queueClient->createQueue('testQueueOne');
         $queueClient->createQueue('testQueueTwo');
@@ -192,15 +195,15 @@ class QueueClient extends atoum\test
 
     public function testQueueClientPurgeQueue()
     {
-        $queueClient = new \ReputationVIP\QueueClient\QueueClient();
+        $queueClient = $this->newTestedInstance();
 
         $queueClient->createQueue('testQueue');
-        $this->class($queueClient->purgeQueue('testQueue'))->hasInterface('ReputationVIP\QueueClient\QueueClientInterface');
+        $this->object($queueClient->purgeQueue('testQueue'))->isTestedInstance();
     }
 
     public function testQueueClientListQueue()
     {
-        $queueClient = new \ReputationVIP\QueueClient\QueueClient(new MemoryAdapter());
+        $queueClient = $this->newTestedInstance(new MemoryAdapter());
 
         $queueClient->createQueue('testQueue');
         $queueClient->createQueue('testRegexQueue');
@@ -215,7 +218,7 @@ class QueueClient extends atoum\test
 
     public function testQueueClientAddAliasWithEmptyAlias()
     {
-        $queueClient = new \ReputationVIP\QueueClient\QueueClient(new MemoryAdapter());
+        $queueClient = $this->newTestedInstance(new MemoryAdapter());
 
         $queueClient->createQueue('testQueue');
         $this->exception(function() use($queueClient) {
@@ -225,7 +228,7 @@ class QueueClient extends atoum\test
 
     public function testQueueClientAddAliasWithEmptyQueueName()
     {
-        $queueClient = new \ReputationVIP\QueueClient\QueueClient(new MemoryAdapter());
+        $queueClient = $this->newTestedInstance(new MemoryAdapter());
 
         $queueClient->createQueue('testQueue');
         $this->exception(function() use($queueClient) {
@@ -235,7 +238,7 @@ class QueueClient extends atoum\test
 
     public function testQueueClientAddAliasOnUndefinedQueue()
     {
-        $queueClient = new \ReputationVIP\QueueClient\QueueClient(new MemoryAdapter());
+        $queueClient = $this->newTestedInstance(new MemoryAdapter());
 
         $this->exception(function() use($queueClient) {
             $queueClient->addAlias('testQueue', 'queueAlias');
@@ -244,19 +247,19 @@ class QueueClient extends atoum\test
 
     public function testQueueClientAddAlias()
     {
-        $queueClient = new \ReputationVIP\QueueClient\QueueClient(new MemoryAdapter());
+        $queueClient = $this->newTestedInstance(new MemoryAdapter());
 
         $queueClient->createQueue('testQueueOne');
         $queueClient->createQueue('testQueueTwo');
-        $this->class($queueClient->addAlias('testQueueOne', 'queueAlias'))->hasInterface('ReputationVIP\QueueClient\QueueClientInterface');
-        $this->class($queueClient->addAlias('testQueueTwo', 'queueAlias'))->hasInterface('ReputationVIP\QueueClient\QueueClientInterface');
+        $this->object($queueClient->addAlias('testQueueOne', 'queueAlias'))->isTestedInstance();
+        $this->object($queueClient->addAlias('testQueueTwo', 'queueAlias'))->isTestedInstance();
         $this->given($queueClient)
             ->array($queueClient->getAliases())->isIdenticalTo(['queueAlias' => ['testQueueOne', 'testQueueTwo']]);
     }
 
     public function testQueueClientRemoveAliasWithUndefinedAlias()
     {
-        $queueClient = new \ReputationVIP\QueueClient\QueueClient(new MemoryAdapter());
+        $queueClient = $this->newTestedInstance(new MemoryAdapter());
 
         $this->exception(function() use($queueClient) {
             $queueClient->RemoveAlias('queueAlias');
@@ -265,20 +268,20 @@ class QueueClient extends atoum\test
 
     public function testQueueClientRemoveAlias()
     {
-        $queueClient = new \ReputationVIP\QueueClient\QueueClient(new MemoryAdapter());
+        $queueClient = $this->newTestedInstance(new MemoryAdapter());
 
         $queueClient->createQueue('testQueueOne');
         $queueClient->createQueue('testQueueTwo');
         $queueClient->addAlias('testQueueOne', 'queueAliasOne');
         $queueClient->addAlias('testQueueTwo', 'queueAliasTwo');
-        $this->class($queueClient->removeAlias('queueAliasOne'))->hasInterface('ReputationVIP\QueueClient\QueueClientInterface');
+        $this->object($queueClient->removeAlias('queueAliasOne'))->isTestedInstance();
         $this->given($queueClient)
             ->array($queueClient->getAliases())->isIdenticalTo(['queueAliasTwo' => ['testQueueTwo']]);
     }
 
     public function testQueueClientGetAliases()
     {
-        $queueClient = new \ReputationVIP\QueueClient\QueueClient(new MemoryAdapter());
+        $queueClient = $this->newTestedInstance(new MemoryAdapter());
 
         $queueClient->createQueue('testQueueOne');
         $queueClient->createQueue('testQueueTwo');
@@ -291,8 +294,8 @@ class QueueClient extends atoum\test
 
     public function testQueueClientGetPriorityHandler()
     {
-        $queueClient = new \ReputationVIP\QueueClient\QueueClient();
+        $queueClient = $this->newTestedInstance();
 
-        $this->class($queueClient->getPriorityHandler())->hasInterface('ReputationVIP\QueueClient\PriorityHandler\PriorityHandlerInterface');
+        $this->object($queueClient->getPriorityHandler())->isInstanceOf('ReputationVIP\QueueClient\PriorityHandler\PriorityHandlerInterface');
     }
 }

--- a/tests/units/QueueClient.php
+++ b/tests/units/QueueClient.php
@@ -2,8 +2,6 @@
 
 namespace ReputationVIP\QueueClient\tests\units;
 
-require_once __DIR__ . '/../../vendor/autoload.php';
-
 use mageekguy\atoum;
 use ReputationVIP\QueueClient\Adapter\MemoryAdapter;
 

--- a/tests/units/QueueClient.php
+++ b/tests/units/QueueClient.php
@@ -12,10 +12,10 @@ class QueueClient extends atoum\test
         $this->testedClass->implements('ReputationVIP\QueueClient\QueueClientInterface');
     }
 
-    public function testQueueClientAddMessageWithAlias()
+    public function testQueueClientAddMessageWithAlias(MemoryAdapter $adapter)
     {
         $this
-            ->given($this->newTestedInstance(new MemoryAdapter()))
+            ->given($this->newTestedInstance($adapter))
             ->when(
                 $this->testedInstance->createQueue('testQueueOne'),
                 $this->testedInstance->createQueue('testQueueTwo'),


### PR DESCRIPTION
This PR is mainly here to show you some tips you can use to write better tests with atoum.

What I did:
- Added a configuration file allowing you tu run your tests with `vendor/bin/atoum` (no need to add the `-d`flag)
- Added a bootstrap file to avoir including the autoloader in each test
- Changed the constraint on atoum to use the stable version
- Rewrote some tests to use `newTestedInstance` and `testedInstance`: those two helpers will make atoum instanciate the tested class for you and internally keep a reference to it so you don't have to use a variable in your tests.
- Automatic collaborators (mock) injection: atoum will automatically provide mocks of type-hinted arguments in test methods so you don't have to instanciate/mock them manually
- Removed some calls to the `class` asserter where possible and used `object(...)->isTestedInstance()`: this is exactly the same as doing `$foo = new myClass(); $this->object($foo->bar())->isIdenticalTo($foo);`
- Removed some calls to `getMockController()` as it's a bit internal. You'd better use `$this->calling($mock)->theMethod = 'hello';`

Everything should just work as it used to work before the PR unless some of you are running on `php < 5.4`
