### PR TITLE
Feature/sqs bulk messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Queue Client Changelog
 
+## v1.0.1
+
+- Send SQS messages in batch
+
 ## v1.0.0
 
 - Initial commit

--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -2,6 +2,37 @@
 
 namespace ReputationVIP\QueueClient\Adapter;
 
+use ReputationVIP\QueueClient\QueueClientInterface;
+
 class AbstractAdapter
 {
+
+    /**
+     * @param string $queueName
+     * @param array  $messages
+     * @param string $priority
+     *
+     * @return QueueClientInterface
+     */
+    public function addMessages($queueName, $messages, $priority = null)
+    {
+        foreach ($messages as $message) {
+            $this->addMessage($queueName, $message, $priority);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param string $queueName
+     * @param mixed  $message
+     * @param string $priority
+     *
+     * @return AdapterInterface
+     */
+    public function addMessage($queueName, $message, $priority = null)
+    {
+        return $this;
+    }
+
 }

--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace ReputationVIP\QueueClient\Adapter;
+
+class AbstractAdapter
+{
+}

--- a/src/Adapter/FileAdapter.php
+++ b/src/Adapter/FileAdapter.php
@@ -12,7 +12,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
-class FileAdapter implements AdapterInterface
+class FileAdapter extends AbstractAdapter implements AdapterInterface
 {
     const QUEUE_FILE_EXTENSION = 'queue';
     const MAX_NB_MESSAGES = 10;

--- a/src/Adapter/MemoryAdapter.php
+++ b/src/Adapter/MemoryAdapter.php
@@ -7,7 +7,7 @@ use ReputationVIP\QueueClient\PriorityHandler\PriorityHandlerInterface;
 use ReputationVIP\QueueClient\PriorityHandler\StandardPriorityHandler;
 use SplQueue;
 
-class MemoryAdapter implements AdapterInterface
+class MemoryAdapter extends AbstractAdapter implements AdapterInterface
 {
     const MAX_TIME_IN_FLIGHT = 30;
 

--- a/src/Adapter/NullAdapter.php
+++ b/src/Adapter/NullAdapter.php
@@ -5,7 +5,7 @@ namespace ReputationVIP\QueueClient\Adapter;
 use ReputationVIP\QueueClient\PriorityHandler\PriorityHandlerInterface;
 use ReputationVIP\QueueClient\PriorityHandler\StandardPriorityHandler;
 
-class NullAdapter implements AdapterInterface
+class NullAdapter extends AbstractAdapter implements AdapterInterface
 {
 
     /** @var PriorityHandlerInterface $priorityHandler */

--- a/src/Adapter/NullAdapter.php
+++ b/src/Adapter/NullAdapter.php
@@ -26,14 +26,6 @@ class NullAdapter extends AbstractAdapter implements AdapterInterface
     /**
      * @inheritdoc
      */
-    public function addMessage($queueName, $message, $priority = null)
-    {
-        return $this;
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getMessages($queueName, $nbMsg = 1, $priority = null)
     {
         return [];

--- a/src/Adapter/SQSAdapter.php
+++ b/src/Adapter/SQSAdapter.php
@@ -19,6 +19,7 @@ class SQSAdapter extends AbstractAdapter implements AdapterInterface
     private $priorityHandler;
 
     const MAX_NB_MESSAGES = 10;
+    const SENT_MESSAGES_BATCH_SIZE = 10;
     const PRIORITY_SEPARATOR = '-';
 
     /**
@@ -48,6 +49,51 @@ class SQSAdapter extends AbstractAdapter implements AdapterInterface
         }
 
         $this->priorityHandler = $priorityHandler;
+        return $this;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function addMessages($queueName, $messages, $priority = null)
+    {
+        if (null === $priority) {
+            $priority = $this->priorityHandler->getDefault();
+        }
+
+        if (empty($queueName)) {
+            throw new InvalidArgumentException('Parameter queueName empty or not defined.');
+        }
+
+        $batchMessages = [];
+        $batchesCount = 0;
+        $blockCounter = 0;
+
+        foreach ($messages as $index => $message) {
+            if (empty($message)) {
+                throw new InvalidArgumentException('Parameter message empty or not defined.');
+            }
+            $messageData = [
+                'Id' => (string) $index,
+                'MessageBody' => serialize($message)
+            ];
+            if ($blockCounter >= self::SENT_MESSAGES_BATCH_SIZE) {
+                $blockCounter = 0;
+                $batchesCount++;
+            } else {
+                $blockCounter++;
+            }
+            $batchMessages[$batchesCount][] = $messageData;
+        }
+
+        foreach ($batchMessages as $messages) {
+            $queueUrl = $this->sqsClient->getQueueUrl(['QueueName' => $this->getQueueNameWithPrioritySuffix($queueName, $priority)])->get('QueueUrl');
+            $this->sqsClient->sendMessageBatch([
+                'QueueUrl' => $queueUrl,
+                'Entries' => $messages,
+            ]);
+        }
+
         return $this;
     }
 

--- a/src/Adapter/SQSAdapter.php
+++ b/src/Adapter/SQSAdapter.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
 use ReputationVIP\QueueClient\PriorityHandler\PriorityHandlerInterface;
 use ReputationVIP\QueueClient\PriorityHandler\StandardPriorityHandler;
 
-class SQSAdapter implements AdapterInterface
+class SQSAdapter extends AbstractAdapter implements AdapterInterface
 {
     /**
      * @var SqsClient

--- a/src/QueueClient.php
+++ b/src/QueueClient.php
@@ -53,13 +53,10 @@ class QueueClient implements QueueClientInterface
      */
     public function addMessage($queueName, $message, $priority = null)
     {
-        $queues = $this->resolveAliasQueueName($queueName);
-        if (is_array($queues)) {
-            foreach ($queues as $queue) {
-                $this->adapter->addMessage($queue, $message, $priority);
-            }
-        } else {
-            $this->adapter->addMessage($queues, $message, $priority);
+        $queues = (array) $this->resolveAliasQueueName($queueName);
+
+        foreach ($queues as $queue) {
+            $this->adapter->addMessage($queue, $message, $priority);
         }
 
         return $this;

--- a/src/QueueClient.php
+++ b/src/QueueClient.php
@@ -67,8 +67,12 @@ class QueueClient implements QueueClientInterface
      */
     public function addMessages($queueName, $messages, $priority = null)
     {
-        foreach ($messages as $message) {
-            $this->addMessage($queueName, $message, $priority);
+        $queues = (array) $this->resolveAliasQueueName($queueName);
+
+        foreach ($queues as $queue) {
+            foreach ($messages as $message) {
+                $this->adapter->addMessage($queue, $message, $priority);
+            }
         }
 
         return $this;

--- a/src/QueueClient.php
+++ b/src/QueueClient.php
@@ -70,9 +70,7 @@ class QueueClient implements QueueClientInterface
         $queues = (array) $this->resolveAliasQueueName($queueName);
 
         foreach ($queues as $queue) {
-            foreach ($messages as $message) {
-                $this->adapter->addMessage($queue, $message, $priority);
-            }
+            $this->adapter->addMessages($queue, $messages, $priority);
         }
 
         return $this;

--- a/tests/units/Adapter/NullAdapter.php
+++ b/tests/units/Adapter/NullAdapter.php
@@ -13,6 +13,12 @@ class NullAdapter extends atoum\test
         $this->given($NullAdapter)->class($NullAdapter->addMessage('testQueue', 'test Message one'))->hasInterface('\ReputationVIP\QueueClient\Adapter\AdapterInterface');
     }
 
+    public function testNullAdapterAddMessages()
+    {
+        $NullAdapter = new \ReputationVIP\QueueClient\Adapter\NullAdapter();
+        $this->given($NullAdapter)->class($NullAdapter->addMessages('testQueue', ['test Message one']))->hasInterface('\ReputationVIP\QueueClient\Adapter\AdapterInterface');
+    }
+
     public function testNullAdapterGetMessages()
     {
         $NullAdapter = new \ReputationVIP\QueueClient\Adapter\NullAdapter();

--- a/tests/units/Adapter/SQSAdapter.php
+++ b/tests/units/Adapter/SQSAdapter.php
@@ -48,6 +48,23 @@ class SQSAdapter extends atoum\test
             ->class($SQSAdapter->addMessage('testQueue', 'test message'))->hasInterface('\ReputationVIP\QueueClient\Adapter\AdapterInterface');
     }
 
+    public function testSQSAdapterAddMessages()
+    {
+        $this->mockGenerator->orphanize('__construct');
+        $this->mockGenerator->shuntParentClassCalls();
+        $mockSqsClient = new \mock\Aws\Sqs\SqsClient;
+        $mockQueueUrlModel = new \mock\Guzzle\Service\Resource\Model;
+        $SQSAdapter = new \ReputationVIP\QueueClient\Adapter\SQSAdapter($mockSqsClient);
+
+        $mockSqsClient->getMockController()->getQueueUrl = function () use($mockQueueUrlModel) {
+            return $mockQueueUrlModel;
+        };
+        $mockSqsClient->getMockController()->sendMessageBatch = function () {
+        };
+        $this->given($SQSAdapter)
+            ->class($SQSAdapter->addMessages('testQueue', ['test message', 'test message 2']))->hasInterface('\ReputationVIP\QueueClient\Adapter\AdapterInterface');
+    }
+
     public function testSQSAdapterGetMessagesWithEmptyQueueName()
     {
         $this->mockGenerator->orphanize('__construct');

--- a/tests/units/Adapter/SQSAdapter.php
+++ b/tests/units/Adapter/SQSAdapter.php
@@ -62,7 +62,31 @@ class SQSAdapter extends atoum\test
         $mockSqsClient->getMockController()->sendMessageBatch = function () {
         };
         $this->given($SQSAdapter)
-            ->class($SQSAdapter->addMessages('testQueue', ['test message', 'test message 2']))->hasInterface('\ReputationVIP\QueueClient\Adapter\AdapterInterface');
+            ->class($SQSAdapter->addMessages('testQueue', array_fill(0, 11, 'test message')))->hasInterface('\ReputationVIP\QueueClient\Adapter\AdapterInterface');
+    }
+
+    public function testSQSAdapterAddMessagesWithEmptyMessage()
+    {
+        $this->mockGenerator->orphanize('__construct');
+        $this->mockGenerator->shuntParentClassCalls();
+        $mockSqsClient = new \mock\Aws\Sqs\SqsClient;
+        $SQSAdapter = new \ReputationVIP\QueueClient\Adapter\SQSAdapter($mockSqsClient);
+
+        $this->exception(function() use($SQSAdapter) {
+            $SQSAdapter->addMessages('testQueue', ['test message', '']);
+        });
+    }
+
+    public function testSQSAdapterAddMessagesWithEmptyQueueName()
+    {
+        $this->mockGenerator->orphanize('__construct');
+        $this->mockGenerator->shuntParentClassCalls();
+        $mockSqsClient = new \mock\Aws\Sqs\SqsClient;
+        $SQSAdapter = new \ReputationVIP\QueueClient\Adapter\SQSAdapter($mockSqsClient);
+
+        $this->exception(function() use($SQSAdapter) {
+            $SQSAdapter->addMessages('', ['']);
+        });
     }
 
     public function testSQSAdapterGetMessagesWithEmptyQueueName()


### PR DESCRIPTION
We used to iterate through each message and therefore send each message individually which added a performance issue. Instead, we prefer to send pools of 10 messages in order to minimize API calls.
