### PR TITLE
Update dependencies for PHP 8.1+ compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,14 +8,14 @@
     }
   ],
   "require": {
-    "symfony/filesystem": "^3.4",
-    "symfony/finder": "^3.4",
-    "symfony/lock": "^3.4",
-    "aws/aws-sdk-php": "^2.7"
+    "symfony/filesystem": "^6.4",
+    "symfony/finder": "^6.4",
+    "symfony/lock": "^6.4",
+    "aws/aws-sdk-php": "^3.328.3"
   },
   "require-dev": {
-    "atoum/atoum": "~3.1",
-    "satooshi/php-coveralls": "^2.0"
+    "atoum/atoum": "^4.2",
+    "php-coveralls/php-coveralls": "^2.7"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
     }
   ],
   "require": {
+    "php": "^8.1",
     "symfony/filesystem": "^6.4",
     "symfony/finder": "^6.4",
     "symfony/lock": "^6.4",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   },
   "require-dev": {
     "atoum/atoum": "~3.1",
-    "satooshi/php-coveralls": "dev-master"
+    "satooshi/php-coveralls": "^2.0"
   },
   "autoload": {
     "psr-4": {

--- a/coverage.php
+++ b/coverage.php
@@ -5,7 +5,7 @@ Sample atoum configuration file to have code coverage in html format and the tre
 Do "php path/to/test/file -c path/to/this/file" or "php path/to/atoum/scripts/runner.php -c path/to/this/file -f path/to/test/file" to use it.
 */
 
-use \mageekguy\atoum;
+use \atoum\atoum;
 
 // HTML
 

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -1,6 +1,6 @@
-FROM php:7.1
+FROM php:8.1
 
-RUN pecl install xdebug-2.9.8
+RUN pecl install xdebug-3.3.2
 RUN docker-php-ext-enable xdebug
 RUN curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/local/bin/composer
@@ -8,5 +8,9 @@ RUN curl -sS https://getcomposer.org/installer | php && \
 RUN apt-get update && apt-get install -y git zip
 
 COPY ./ssh/ssh_config /etc/ssh/ssh_config
+
+COPY ./conf.d  /usr/local/etc/php/conf.d
+
+RUN mkdir "/tmp/test"
 
 WORKDIR /data

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -11,6 +11,4 @@ COPY ./ssh/ssh_config /etc/ssh/ssh_config
 
 COPY ./conf.d  /usr/local/etc/php/conf.d
 
-RUN mkdir "/tmp/test"
-
 WORKDIR /data

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -1,11 +1,11 @@
 FROM php:7.1
 
-RUN pecl install xdebug
+RUN pecl install xdebug-2.9.8
 RUN docker-php-ext-enable xdebug
 RUN curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/local/bin/composer
-RUN apt-get update && apt-get install -y \
-    git
+
+RUN apt-get update && apt-get install -y git zip
 
 COPY ./ssh/ssh_config /etc/ssh/ssh_config
 

--- a/docker/test/conf.d/xdebug.ini
+++ b/docker/test/conf.d/xdebug.ini
@@ -1,0 +1,1 @@
+xdebug.mode=coverage

--- a/src/Adapter/FileAdapter.php
+++ b/src/Adapter/FileAdapter.php
@@ -11,7 +11,7 @@ use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
-use Symfony\Component\Lock\Factory;
+use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\Store\FlockStore;
 
 class FileAdapter extends AbstractAdapter implements AdapterInterface
@@ -31,7 +31,7 @@ class FileAdapter extends AbstractAdapter implements AdapterInterface
     /** @var Filesystem $fs */
     private $fs;
 
-    /** @var Factory $lockHandlerFactory */
+    /** @var LockFactory $lockHandlerFactory */
     private $lockHandlerFactory;
 
     /** @var PriorityHandlerInterface $priorityHandler */
@@ -42,12 +42,12 @@ class FileAdapter extends AbstractAdapter implements AdapterInterface
      * @param PriorityHandlerInterface $priorityHandler
      * @param Filesystem $fs
      * @param Finder $finder
-     * @param Factory $lockHandlerFactory
+     * @param LockFactory $lockHandlerFactory
      *
      * @throws \InvalidArgumentException
      * @throws QueueAccessException
      */
-    public function __construct($repository, PriorityHandlerInterface $priorityHandler = null, Filesystem $fs = null, Finder $finder = null, Factory $lockHandlerFactory = null)
+    public function __construct(string $repository, PriorityHandlerInterface $priorityHandler = null, Filesystem $fs = null, Finder $finder = null, LockFactory $lockHandlerFactory = null)
     {
         if (empty($repository)) {
             throw new \InvalidArgumentException('Argument repository empty or not defined.');
@@ -76,7 +76,7 @@ class FileAdapter extends AbstractAdapter implements AdapterInterface
         }
 
         if (null === $lockHandlerFactory) {
-            $lockHandlerFactory = new Factory(new FlockStore($repository));
+            $lockHandlerFactory = new LockFactory(new FlockStore($repository));
         }
 
         $this->priorityHandler = $priorityHandler;

--- a/tests/units/Adapter/FileAdapter.php
+++ b/tests/units/Adapter/FileAdapter.php
@@ -3,16 +3,15 @@
 namespace ReputationVIP\QueueClient\tests\units\Adapter;
 
 use ArrayIterator;
-use mageekguy\atoum;
+use atoum\atoum;
 use ReputationVIP\QueueClient\PriorityHandler\ThreeLevelPriorityHandler;
 use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
-use Symfony\Component\Lock\Factory;
 
 class MockIOExceptionInterface extends \Exception implements IOExceptionInterface
 {
-    public function getPath()
+    public function getPath(): ?string
     {
         return '';
     }
@@ -33,7 +32,7 @@ class FileAdapter extends atoum\test
     public function testFileAdapter__constructWithFilesystemError(Filesystem $fs, Finder $finder)
     {
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $this->exception(function () use ($fs, $finder, $mockLockHandlerFactory) {
             $this->newTestedInstance('', null, $fs, $finder, $mockLockHandlerFactory);
@@ -51,10 +50,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $this->calling($mockFs)->exists = true;
         $this->calling($mockLockHandlerFactory)->createLock = function ($repository) {
@@ -71,10 +73,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $this->calling($mockFs)->exists = true;
         $fileAdapter = new \ReputationVIP\QueueClient\Adapter\FileAdapter('/tmp/test/', null, $mockFs, $mockFinder, $mockLockHandlerFactory);
@@ -87,10 +92,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $this->calling($mockFs)->exists = false;
         $this->calling($mockLockHandlerFactory)->createLock = function ($repository) {
@@ -108,10 +116,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $this->calling($mockFs)->exists = true;
         $this->calling($mockLockHandlerFactory)->createLock = function ($repository) {
@@ -129,10 +140,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $mockLockHandlerFactory->getMockController()->createLock = function ($repository) {
             $mockLockHandler = new \mock\Symfony\Component\Lock\LockInterface;
@@ -149,10 +163,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $mockLockHandlerFactory->getMockController()->createLock = function ($repository) {
             $mockLockHandler = new \mock\Symfony\Component\Lock\LockInterface;
@@ -173,10 +190,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $mockLockHandlerFactory->getMockController()->createLock = function ($repository) {
             $mockLockHandler = new \mock\Symfony\Component\Lock\LockInterface;
@@ -194,10 +214,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $this->calling($mockFs)->exists = true;
         $fileAdapter = new \ReputationVIP\QueueClient\Adapter\FileAdapter('/tmp/test/', null, $mockFs, $mockFinder, $mockLockHandlerFactory);
@@ -210,10 +233,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $mockFs->getMockController()->exists = true;
         $fileAdapter = new \ReputationVIP\QueueClient\Adapter\FileAdapter('/tmp/test/', null, $mockFs, $mockFinder, $mockLockHandlerFactory);
@@ -226,10 +252,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $mockFs->getMockController()->exists = false;
         $fileAdapter = new \ReputationVIP\QueueClient\Adapter\FileAdapter('/tmp/test/', null, $mockFs, $mockFinder, $mockLockHandlerFactory);
@@ -242,10 +271,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $priorityHandler = new ThreeLevelPriorityHandler();
         $mockFs->getMockController()->exists = true;
@@ -289,10 +321,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $mockFs->getMockController()->exists = false;
         $FileAdapter = new \ReputationVIP\QueueClient\Adapter\FileAdapter('/tmp/test/', null, $mockFs, $mockFinder, $mockLockHandlerFactory);
@@ -305,10 +340,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $fileAdapter = new \ReputationVIP\QueueClient\Adapter\FileAdapter('/tmp/test/', null, $mockFs, $mockFinder, $mockLockHandlerFactory);
         $this->exception(function () use ($fileAdapter) {
@@ -320,10 +358,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $mockFs->getMockController()->exists = true;
         $mockLockHandlerFactory->getMockController()->createLock = function ($repository) {
@@ -341,10 +382,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $priorityHandler = new ThreeLevelPriorityHandler();
         $mockFs->getMockController()->exists = true;
@@ -389,10 +433,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $priorityHandler = new ThreeLevelPriorityHandler();
         $mockFs->getMockController()->exists = true;
@@ -437,10 +484,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $priorityHandler = new ThreeLevelPriorityHandler();
         $mockFs->getMockController()->exists = true;
@@ -487,10 +537,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $priorityHandler = new ThreeLevelPriorityHandler();
         $mockFs->getMockController()->exists = true;
@@ -528,10 +581,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $mockFs->getMockController()->exists = true;
         $fileAdapter = new \ReputationVIP\QueueClient\Adapter\FileAdapter('/tmp/test/', null, $mockFs, $mockFinder, $mockLockHandlerFactory);
@@ -544,10 +600,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $mockFs->getMockController()->exists = false;
         $fileAdapter = new \ReputationVIP\QueueClient\Adapter\FileAdapter('/tmp/test/', null, $mockFs, $mockFinder, $mockLockHandlerFactory);
@@ -560,10 +619,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $priorityHandler = new ThreeLevelPriorityHandler();
         $mockFs->getMockController()->exists = true;
@@ -608,10 +670,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $priorityHandler = new ThreeLevelPriorityHandler();
         $mockFs->getMockController()->exists = true;
@@ -656,10 +721,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $priorityHandler = new ThreeLevelPriorityHandler();
         $mockFinder->getMockController()->getIterator = function () use ($priorityHandler) {
@@ -696,10 +764,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $priorityHandler = new ThreeLevelPriorityHandler();
         $mockFinder->getMockController()->getIterator = function () use ($priorityHandler) {
@@ -736,10 +807,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $mockFinder->getMockController()->getIterator = function () {
             return new ArrayIterator([]);
@@ -755,10 +829,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $priorityHandler = new ThreeLevelPriorityHandler();
         $mockFs->getMockController()->exists = true;
@@ -801,9 +878,12 @@ class FileAdapter extends atoum\test
     public function testFileAdapterAddMessageWithDelay()
     {
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $priorityHandler = new ThreeLevelPriorityHandler();
         $fileAdapter = new \ReputationVIP\QueueClient\Adapter\FileAdapter('/tmp/test/', $priorityHandler, $mockFs, $mockFinder, $mockLockHandlerFactory);
@@ -841,10 +921,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $fileAdapter = new \ReputationVIP\QueueClient\Adapter\FileAdapter('/tmp/test/', null, $mockFs, $mockFinder, $mockLockHandlerFactory);
         $this->exception(function () use ($fileAdapter) {
@@ -856,10 +939,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $mockFs->getMockController()->exists = false;
         $fileAdapter = new \ReputationVIP\QueueClient\Adapter\FileAdapter('/tmp/test/', null, $mockFs, $mockFinder, $mockLockHandlerFactory);
@@ -872,10 +958,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $mockFs->getMockController()->exists = true;
         $mockLockHandlerFactory->getMockController()->createLock = function ($repository) {
@@ -893,10 +982,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $mockFs->getMockController()->exists = true;
         $mockLockHandlerFactory->getMockController()->createLock = function ($repository) {
@@ -914,10 +1006,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $priorityHandler = new ThreeLevelPriorityHandler();
         $mockFs->getMockController()->exists = true;
@@ -962,10 +1057,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $priorityHandler = new ThreeLevelPriorityHandler();
         $mockFs->getMockController()->exists = true;
@@ -1010,10 +1108,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $fileAdapter = new \ReputationVIP\QueueClient\Adapter\FileAdapter('/tmp/test/', null, $mockFs, $mockFinder, $mockLockHandlerFactory);
         $this->exception(function () use ($fileAdapter) {
@@ -1025,10 +1126,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $mockFs->getMockController()->exists = false;
         $fileAdapter = new \ReputationVIP\QueueClient\Adapter\FileAdapter('/tmp/test/', null, $mockFs, $mockFinder, $mockLockHandlerFactory);
@@ -1041,10 +1145,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $mockFs->getMockController()->exists = true;
         $mockLockHandlerFactory->getMockController()->createLock = function ($repository) {
@@ -1062,10 +1169,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $priorityHandler = new ThreeLevelPriorityHandler();
         $mockFs->getMockController()->exists = true;
@@ -1110,10 +1220,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $priorityHandler = new ThreeLevelPriorityHandler();
         $mockFs->getMockController()->exists = true;
@@ -1158,10 +1271,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $priorityHandler = new ThreeLevelPriorityHandler();
         $mockFs->getMockController()->exists = true;
@@ -1197,10 +1313,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $fileAdapter = new \ReputationVIP\QueueClient\Adapter\FileAdapter('/tmp/test/', null, $mockFs, $mockFinder, $mockLockHandlerFactory);
         $this->exception(function () use ($fileAdapter) {
@@ -1212,10 +1331,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $mockFs->getMockController()->exists = false;
         $fileAdapter = new \ReputationVIP\QueueClient\Adapter\FileAdapter('/tmp/test/', null, $mockFs, $mockFinder, $mockLockHandlerFactory);
@@ -1228,10 +1350,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $mockFs->getMockController()->exists = true;
         $mockLockHandlerFactory->getMockController()->createLock = function ($repository) {
@@ -1249,10 +1374,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $mockFs->getMockController()->exists = true;
         $mockLockHandlerFactory->getMockController()->createLock = function ($repository) {
@@ -1273,10 +1401,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $mockFs->getMockController()->exists = true;
         $mockLockHandlerFactory->getMockController()->createLock = function ($repository) {
@@ -1294,10 +1425,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $priorityHandler = new ThreeLevelPriorityHandler();
         $mockFs->getMockController()->exists = true;
@@ -1342,10 +1476,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $priorityHandler = new ThreeLevelPriorityHandler();
         $mockFs->getMockController()->exists = true;
@@ -1390,10 +1527,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $priorityHandler = new ThreeLevelPriorityHandler();
         $mockFs->getMockController()->exists = true;
@@ -1431,10 +1571,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $fileAdapter = new \ReputationVIP\QueueClient\Adapter\FileAdapter('/tmp/test/', null, $mockFs, $mockFinder, $mockLockHandlerFactory);
         $this->exception(function () use ($fileAdapter) {
@@ -1446,10 +1589,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $priorityHandler = new ThreeLevelPriorityHandler();
         $mockFs->getMockController()->exists = false;
@@ -1463,10 +1609,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $mockFs->getMockController()->exists = false;
         $fileAdapter = new \ReputationVIP\QueueClient\Adapter\FileAdapter('/tmp/test/', null, $mockFs, $mockFinder, $mockLockHandlerFactory);
@@ -1479,10 +1628,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $priorityHandler = new ThreeLevelPriorityHandler();
         $mockFs->getMockController()->exists = true;
@@ -1496,10 +1648,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $mockFs->getMockController()->exists = true;
         $fileAdapter = new \ReputationVIP\QueueClient\Adapter\FileAdapter('/tmp/test/', null, $mockFs, $mockFinder, $mockLockHandlerFactory);
@@ -1512,10 +1667,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $mockFs->getMockController()->exists = true;
         $fileAdapter = new \ReputationVIP\QueueClient\Adapter\FileAdapter('/tmp/test/', null, $mockFs, $mockFinder, $mockLockHandlerFactory);
@@ -1528,10 +1686,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $priorityHandler = new ThreeLevelPriorityHandler();
         $mockFs->getMockController()->exists = true;
@@ -1550,10 +1711,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $priorityHandler = new ThreeLevelPriorityHandler();
         $mockFs->getMockController()->exists = true;
@@ -1598,10 +1762,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $priorityHandler = new ThreeLevelPriorityHandler();
         $mockFs->getMockController()->exists = true;
@@ -1646,10 +1813,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $priorityHandler = new ThreeLevelPriorityHandler();
         $mockFs->getMockController()->exists = true;
@@ -1685,10 +1855,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $fileAdapter = new \ReputationVIP\QueueClient\Adapter\FileAdapter('/tmp/test/', null, $mockFs, $mockFinder, $mockLockHandlerFactory);
         $this->exception(function () use ($fileAdapter) {
@@ -1703,10 +1876,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $priorityHandler = new ThreeLevelPriorityHandler();
         $mockFs->getMockController()->exists = function ($queue) {
@@ -1747,10 +1923,13 @@ class FileAdapter extends atoum\test
     {
         $this->mockGenerator->shuntParentClassCalls();
         $mockFs = new \mock\Symfony\Component\Filesystem\Filesystem;
+        $mockFs->getMockController()->exists = function ($path) {
+            return false;
+        };
         $this->mockGenerator->unshuntParentClassCalls();
         $mockFinder = new \mock\Symfony\Component\Finder\Finder;
         $this->mockGenerator->orphanize('__construct');
-        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\Factory;
+        $mockLockHandlerFactory = new \mock\Symfony\Component\Lock\LockFactory;
 
         $fileAdapter = new \ReputationVIP\QueueClient\Adapter\FileAdapter('/tmp/test/', null, $mockFs, $mockFinder, $mockLockHandlerFactory);
         $this->given($fileAdapter)

--- a/tests/units/Adapter/FileAdapter.php
+++ b/tests/units/Adapter/FileAdapter.php
@@ -19,6 +19,13 @@ class MockIOExceptionInterface extends \Exception implements IOExceptionInterfac
 
 class FileAdapter extends atoum\test
 {
+    public function setUp(): void
+    {
+        if (!is_dir('/tmp/test')) {
+            mkdir('/tmp/test', 0777, true);
+        }
+    }
+
     public function testFileAdapterClass()
     {
         $this->testedClass->implements('\ReputationVIP\QueueClient\Adapter\AdapterInterface');

--- a/tests/units/Adapter/MemoryAdapter.php
+++ b/tests/units/Adapter/MemoryAdapter.php
@@ -2,7 +2,7 @@
 
 namespace ReputationVIP\QueueClient\tests\units\Adapter;
 
-use mageekguy\atoum;
+use atoum\atoum;
 use ReputationVIP\QueueClient\PriorityHandler\Priority\Priority;
 use ReputationVIP\QueueClient\PriorityHandler\StandardPriorityHandler;
 use ReputationVIP\QueueClient\PriorityHandler\ThreeLevelPriorityHandler;

--- a/tests/units/Adapter/NullAdapter.php
+++ b/tests/units/Adapter/NullAdapter.php
@@ -2,7 +2,7 @@
 
 namespace ReputationVIP\QueueClient\tests\units\Adapter;
 
-use mageekguy\atoum;
+use atoum\atoum;
 
 class NullAdapter extends atoum\test
 {

--- a/tests/units/Adapter/SQSAdapter.php
+++ b/tests/units/Adapter/SQSAdapter.php
@@ -2,7 +2,7 @@
 
 namespace ReputationVIP\QueueClient\tests\units\Adapter;
 
-use mageekguy\atoum;
+use atoum\atoum;
 use ReputationVIP\QueueClient\PriorityHandler\ThreeLevelPriorityHandler;
 
 class SQSAdapter extends atoum\test

--- a/tests/units/PriorityHandler/StandardPriorityHandler.php
+++ b/tests/units/PriorityHandler/StandardPriorityHandler.php
@@ -2,7 +2,7 @@
 
 namespace ReputationVIP\QueueClient\tests\units\PriorityHandler;
 
-use mageekguy\atoum;
+use atoum\atoum;
 use ReputationVIP\QueueClient\PriorityHandler\Priority\Priority;
 
 class StandardPriorityHandler extends atoum\test

--- a/tests/units/QueueClient.php
+++ b/tests/units/QueueClient.php
@@ -2,7 +2,7 @@
 
 namespace ReputationVIP\QueueClient\tests\units;
 
-use mageekguy\atoum;
+use atoum\atoum;
 use ReputationVIP\QueueClient\Adapter\MemoryAdapter;
 
 class QueueClient extends atoum\test

--- a/travis-coverage.php
+++ b/travis-coverage.php
@@ -5,11 +5,11 @@ Sample atoum configuration file to have code coverage in html format and the tre
 Do "php path/to/test/file -c path/to/this/file" or "php path/to/atoum/scripts/runner.php -c path/to/this/file -f path/to/test/file" to use it.
 */
 
-use \mageekguy\atoum;
+use \atoum\atoum;
 
 $cloverWriter = new atoum\writers\file('build/logs/clover.xml');
-$stdOutWriter = new \mageekguy\atoum\writers\std\out();
-$cli = new \mageekguy\atoum\reports\realtime\cli();
+$stdOutWriter = new \atoum\atoum\writers\std\out();
+$cli = new \atoum\atoum\reports\realtime\cli();
 $cli->addWriter($stdOutWriter);
 $cloverReport = new atoum\reports\asynchronous\clover();
 $cloverReport->addWriter($cloverWriter);


### PR DESCRIPTION
This PR updates dependencies to ensure compatibility with PHP 8.1 and higher.

Upgraded aws/aws-sdk-php from v2 to v3, as v2 relies on the outdated guzzle/guzzle library, which is incompatible with PHP 8+.
Updated other dependencies to their latest stable versions where applicable.